### PR TITLE
Add omitempty to Trigger.Active

### DIFF
--- a/zendesk/trigger.go
+++ b/zendesk/trigger.go
@@ -52,7 +52,7 @@ func (tav *TriggerActionValue) UnmarshalJSON(data []byte) error {
 type Trigger struct {
 	ID         int64  `json:"id,omitempty"`
 	Title      string `json:"title"`
-	Active     bool   `json:"active"`
+	Active     bool   `json:"active,omitempty"`
 	Position   int64  `json:"position,omitempty"`
 	Conditions struct {
 		All []TriggerCondition `json:"all"`


### PR DESCRIPTION
If `omitempty` is specified, `active: false` will be sent.
But it isn't expected behavior in general.