### PR TITLE
Adding error type that exposes the response from zendesk

### DIFF
--- a/zendesk/error_test.go
+++ b/zendesk/error_test.go
@@ -1,0 +1,35 @@
+package zendesk
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestError_Response(t *testing.T) {
+	resp := &http.Response{}
+	err := Error{
+		msg:  "foo",
+		resp: resp,
+	}
+
+	if err.Response() != resp {
+		t.Fatal("Response did not  return the provided response")
+	}
+}
+
+func TestError_Error(t *testing.T) {
+	status := http.StatusOK
+	resp := &http.Response{
+		StatusCode: status,
+	}
+	body := "foo"
+	err := Error{
+		msg:  body,
+		resp: resp,
+	}
+
+	if err.Error() != fmt.Sprintf("%d: %s", status, body) {
+		t.Fatal("Error did not have expected value")
+	}
+}

--- a/zendesk/zendesk_test.go
+++ b/zendesk/zendesk_test.go
@@ -123,6 +123,21 @@ func TestGet(t *testing.T) {
 	}
 }
 
+func TestGetFailure(t *testing.T) {
+	mockAPI := newMockAPIWithStatus(http.MethodGet, "groups.json", http.StatusInternalServerError)
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	_, err := client.Get("/groups.json")
+	if err == nil {
+		t.Fatal("Did not receive error from client")
+	}
+
+	if _, ok := err.(Error); !ok {
+		t.Fatalf("Did not return a zendesk error %s", err)
+	}
+}
+
 func TestPost(t *testing.T) {
 	mockAPI := newMockAPIWithStatus(http.MethodPost, "groups.json", http.StatusCreated)
 	client := newTestClient(mockAPI)
@@ -135,6 +150,21 @@ func TestPost(t *testing.T) {
 
 	if len(body) == 0 {
 		t.Fatal("Response body is empty")
+	}
+}
+
+func TestPostFailure(t *testing.T) {
+	mockAPI := newMockAPIWithStatus(http.MethodPost, "groups.json", http.StatusInternalServerError)
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	_, err := client.Post("/groups.json", Group{})
+	if err == nil {
+		t.Fatal("Did not receive error from client")
+	}
+
+	if _, ok := err.(Error); !ok {
+		t.Fatalf("Did not return a zendesk error %s", err)
 	}
 }
 


### PR DESCRIPTION
Creating error type inspired by https://github.com/fprimex/zdesk/blob/master/zdesk/zdesk.py#L68-L75.

Error exposes the zendesk http response to the client as well as the response body.