### PR TITLE
Use go modules on supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,28 @@
 language: go
 
-go:
-  - 1.9
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
-  - master
+matrix:
+  include:
+  - go: 1.9
+  - go: 1.10.x
+  - go: 1.11.x
+    env: GO111MODULE=on
+  - go: 1.12.x
+    env: GO111MODULE=on
+  - go: master
+    env: GO111MODULE=on
 
 before_install:
-  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  - if [ $GO111MODULE != "on" ]; then
+      curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh;
+    fi
   - go get github.com/mattn/goveralls # for profiling coverage
 
 install:
-  - dep ensure
+  - if [ $GO111MODULE == "on" ]; then
+      go mod download;
+    else
+      dep ensure;
+    fi
 
 script:
   - go test -v ./...

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,19 @@
 build: off
 
-clone_folder: c:\gopath\src\github.com\nukosuke\go-zendesk
+clone_folder: c:\github.com\nukosuke\go-zendesk
 
 environment:
   GOPATH: c:\gopath
+  GO111MODULE: on
+
+cache:
+  - '%LocalAppData%\go-build'
+  - '%GOPATH%\pkg\mod'
 
 stack: go 1.11
 
 install:
-  - go get -u github.com/golang/dep/...
-  - set PATH=%PATH%;%GOPATH%\bin
-  - dep ensure
+  - go mod download
 
 before_test:
   - go vet ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/nukosuke/go-zendesk
+
+require github.com/golang/mock v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
+github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=


### PR DESCRIPTION
I'm planning to remove `dep` when Go 1.9 and 1.10 would be obsolete.
But it is supported only for these versions for now.