### PR TITLE
Updates to the zendesk Error type

### DIFF
--- a/zendesk/error_test.go
+++ b/zendesk/error_test.go
@@ -21,3 +21,39 @@ func TestError_Error(t *testing.T) {
 		t.Fatal("Error did not have expected value")
 	}
 }
+
+func TestError_Headers(t *testing.T) {
+	retryAfter := "Retry-After"
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header: http.Header{
+			retryAfter: []string{"92"},
+		},
+	}
+
+	err := Error{
+		resp: resp,
+	}
+
+	if _, ok := err.Headers()[retryAfter]; !ok {
+		t.Fatal("Could not get header values from zendesk error")
+	}
+}
+
+func TestError_Status(t *testing.T) {
+	retryAfter := "Retry-After"
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header: http.Header{
+			retryAfter: []string{"92"},
+		},
+	}
+
+	err := Error{
+		resp: resp,
+	}
+
+	if status := err.Status(); status != http.StatusTooManyRequests {
+		t.Fatal("Status returned from error was not the correct status code")
+	}
+}

--- a/zendesk/error_test.go
+++ b/zendesk/error_test.go
@@ -17,8 +17,24 @@ func TestError_Error(t *testing.T) {
 		resp: resp,
 	}
 
-	if err.Error() != fmt.Sprintf("%d: %s", status, body) {
-		t.Fatal("Error did not have expected value")
+	expected := fmt.Sprintf("%d: %s", status, body)
+	if v := err.Error(); v != expected {
+		t.Fatalf("Error %s did not have expected value %s", v, expected)
+	}
+}
+
+func TestError_ErrorEmptyBody(t *testing.T) {
+	status := http.StatusOK
+	resp := &http.Response{
+		StatusCode: status,
+	}
+	err := Error{
+		resp: resp,
+	}
+
+	expected := fmt.Sprintf("%d: %s", status, http.StatusText(status))
+	if v := err.Error(); v != expected {
+		t.Fatalf("Error %s did not have expected value %s", v, expected)
 	}
 }
 

--- a/zendesk/error_test.go
+++ b/zendesk/error_test.go
@@ -6,26 +6,14 @@ import (
 	"testing"
 )
 
-func TestError_Response(t *testing.T) {
-	resp := &http.Response{}
-	err := Error{
-		msg:  "foo",
-		resp: resp,
-	}
-
-	if err.Response() != resp {
-		t.Fatal("Response did not  return the provided response")
-	}
-}
-
 func TestError_Error(t *testing.T) {
 	status := http.StatusOK
 	resp := &http.Response{
 		StatusCode: status,
 	}
-	body := "foo"
+	body := []byte("foo")
 	err := Error{
-		msg:  body,
+		body: body,
 		resp: resp,
 	}
 

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -31,7 +31,12 @@ type Error struct {
 
 // Error the error string for this error
 func (e Error) Error() string {
-	return fmt.Sprintf("%d: %s", e.resp.StatusCode, string(e.body))
+	msg := string(e.body)
+	if msg == "" {
+		msg = http.StatusText(e.Status())
+	}
+
+	return fmt.Sprintf("%d: %s", e.resp.StatusCode, msg)
 }
 
 // Body is the Body of the HTTP response

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -1,8 +1,10 @@
 package zendesk
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -23,18 +25,28 @@ var defaultHeaders = map[string]string{
 
 // Error an error type containing the http response from zendesk
 type Error struct {
+	body []byte
 	resp *http.Response
-	msg  string
 }
 
 // Error the error string for this error
 func (e Error) Error() string {
-	return fmt.Sprintf("%d: %s", e.resp.StatusCode, e.msg)
+	return fmt.Sprintf("%d: %s", e.resp.StatusCode, string(e.body))
 }
 
-// Response the http response returned by zendesk
-func (e Error) Response() *http.Response {
-	return e.resp
+// Body is the Body of the HTTP response
+func (e Error) Body() io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewBuffer(e.body))
+}
+
+// Headers the HTTP headers returned from zendesk
+func (e Error) Headers() http.Header {
+	return e.resp.Header
+}
+
+// Status the HTTP status code returned from zendesk
+func (e Error) Status() int {
+	return e.resp.StatusCode
 }
 
 var subdomainRegexp = regexp.MustCompile("^[a-z][a-z0-9-]+[a-z0-9]$")
@@ -120,7 +132,7 @@ func (z Client) Get(path string) ([]byte, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, Error{
-			msg:  string(body),
+			body: body,
 			resp: resp,
 		}
 	}
@@ -153,7 +165,7 @@ func (z Client) Post(path string, data interface{}) ([]byte, error) {
 
 	if resp.StatusCode != http.StatusCreated {
 		return nil, Error{
-			msg:  string(body),
+			body: body,
 			resp: resp,
 		}
 	}
@@ -187,7 +199,7 @@ func (z Client) Put(path string, data interface{}) ([]byte, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, Error{
-			msg:  string(body),
+			body: body,
 			resp: resp,
 		}
 	}
@@ -216,7 +228,7 @@ func (z Client) Delete(path string) error {
 
 	if resp.StatusCode != http.StatusNoContent {
 		return Error{
-			msg:  string(body),
+			body: body,
 			resp: resp,
 		}
 	}

--- a/zendesk/zendesk_test.go
+++ b/zendesk/zendesk_test.go
@@ -138,6 +138,33 @@ func TestGetFailure(t *testing.T) {
 	}
 }
 
+func TestGetFailureCanReadErrorBody(t *testing.T) {
+	mockAPI := newMockAPIWithStatus(http.MethodGet, "groups.json", http.StatusInternalServerError)
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	_, err := client.Get("/groups.json")
+	if err == nil {
+		t.Fatal("Did not receive error from client")
+	}
+
+	clientErr, ok := err.(Error)
+	if !ok {
+		t.Fatalf("Did not return a zendesk error %s", err)
+	}
+
+	body := clientErr.Response().Body
+	_, err = ioutil.ReadAll(body)
+	if err != nil {
+		t.Fatal("Client received error while reading client body")
+	}
+
+	err = body.Close()
+	if err != nil {
+		t.Fatal("Client received error while closing body")
+	}
+}
+
 func TestPost(t *testing.T) {
 	mockAPI := newMockAPIWithStatus(http.MethodPost, "groups.json", http.StatusCreated)
 	client := newTestClient(mockAPI)

--- a/zendesk/zendesk_test.go
+++ b/zendesk/zendesk_test.go
@@ -153,7 +153,7 @@ func TestGetFailureCanReadErrorBody(t *testing.T) {
 		t.Fatalf("Did not return a zendesk error %s", err)
 	}
 
-	body := clientErr.Response().Body
+	body := clientErr.Body()
 	_, err = ioutil.ReadAll(body)
 	if err != nil {
 		t.Fatal("Client received error while reading client body")


### PR DESCRIPTION
Determined through testing that downstream clients could not read the ZendeskError body. Refactored the error a bit to allow clients to read HTTP response body downstream.