### PR TITLE
Add context support for GetUserFields()

### DIFF
--- a/zendesk/user_field.go
+++ b/zendesk/user_field.go
@@ -1,6 +1,7 @@
 package zendesk
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 )
@@ -26,12 +27,14 @@ type UserField struct {
 }
 
 // GetUserFields fetch trigger list
-func (z *Client) GetUserFields() ([]UserField, Page, error) {
+//
+// https://developer.zendesk.com/rest_api/docs/support/user_fields#list-user-fields
+func (z *Client) GetUserFields(ctx context.Context) ([]UserField, Page, error) {
 	var data struct {
 		UserFields []UserField `json:"user_fields"`
 		Page
 	}
-	body, err := z.Get("/user_fields.json")
+	body, err := z.get(ctx, "/user_fields.json")
 	if err != nil {
 		return nil, Page{}, err
 	}


### PR DESCRIPTION
#70 

Add context support for GetUserFields()

But, I think that we don't have to support this API at v0.3.0 because user_field has no test and fundamental CRUD methods are missing. It will be scheduled on milestone >= v0.3.1