### PR TITLE
Fix field of brand, ticket_form_ids

### DIFF
--- a/zendesk/brand.go
+++ b/zendesk/brand.go
@@ -19,7 +19,7 @@ type Brand struct {
 	Active            bool       `json:"active,omitempty"`
 	Default           bool       `json:"default,omitempty"`
 	Logo              Attachment `json:"logo,omitempty"`
-	TicketFieldIDs    []int64    `json:"ticket_field_ids,omitempty"`
+	TicketFormIDs     []int64    `json:"ticket_form_ids,omitempty"`
 	Subdomain         string     `json:"subdomain"`
 	HostMapping       string     `json:"host_mapping,omitempty"`
 	SignatureTemplate string     `json:"signature_template"`


### PR DESCRIPTION
Fix #128 

`ticket_field_ids` is not attribute of brand, but `ticket_form_ids`.

This also should be patched to v0.2.1