### PR TITLE
Target support

### DIFF
--- a/fixture/GET/target.json
+++ b/fixture/GET/target.json
@@ -1,0 +1,15 @@
+{
+    "target": {
+        "url": "https://example.zendesk.com/api/v2/targets/360000217439.json",
+        "id": 360000217439,
+        "created_at": "2019-09-29T08:11:03Z",
+        "type": "http_target",
+        "title": "target :: http :: postbin",
+        "active": true,
+        "method": "post",
+        "username": "",
+        "password": null,
+        "content_type": "application/json",
+        "target_url": "https://postb.in/WERcssi2"
+    }
+}

--- a/fixture/GET/targets.json
+++ b/fixture/GET/targets.json
@@ -1,0 +1,30 @@
+{
+    "targets": [
+        {
+            "url": "https://example.zendesk.com/api/v2/targets/360000217438.json",
+            "id": 360000217438,
+            "created_at": "2019-09-29T08:11:03Z",
+            "type": "http_target",
+            "title": "target :: http :: postbin",
+            "active": true,
+            "method": "post",
+            "username": "",
+            "password": null,
+            "content_type": "application/json",
+            "target_url": "https://postb.in/WERcssi2"
+        },
+        {
+            "url": "https://example.zendesk.com/api/v2/targets/360000217439.json",
+            "id": 360000217439,
+            "created_at": "2019-09-29T08:11:03Z",
+            "type": "email_target",
+            "title": "target :: email :: john.doe@example.com",
+            "active": true,
+            "email": "john.doe@example.com",
+            "subject": "New ticket created"
+        }
+    ],
+    "next_page": null,
+    "previous_page": null,
+    "count": 2
+}

--- a/fixture/POST/target.json
+++ b/fixture/POST/target.json
@@ -1,0 +1,15 @@
+{
+    "target": {
+        "url": "https://example.zendesk.com/api/v2/targets/360000217439.json",
+        "id": 360000217439,
+        "created_at": "2019-09-29T08:11:03Z",
+        "type": "http_target",
+        "title": "target :: http :: postbin",
+        "active": true,
+        "method": "post",
+        "username": "",
+        "password": null,
+        "content_type": "application/json",
+        "target_url": "https://postb.in/WERcssi2"
+    }
+}

--- a/fixture/PUT/target.json
+++ b/fixture/PUT/target.json
@@ -1,0 +1,15 @@
+{
+    "target": {
+        "url": "https://example.zendesk.com/api/v2/targets/360000217439.json",
+        "id": 360000217439,
+        "created_at": "2019-09-29T08:11:03Z",
+        "type": "http_target",
+        "title": "target :: http :: postbin",
+        "active": true,
+        "method": "post",
+        "username": "",
+        "password": null,
+        "content_type": "application/json",
+        "target_url": "https://postb.in/WERcssi2"
+    }
+}

--- a/zendesk/api.go
+++ b/zendesk/api.go
@@ -14,6 +14,7 @@ type API interface {
 	TicketFieldAPI
 	TicketFormAPI
 	TriggerAPI
+	TargetAPI
 	UserAPI
 }
 

--- a/zendesk/main_test.go
+++ b/zendesk/main_test.go
@@ -2,4 +2,4 @@ package zendesk
 
 import "context"
 
-var ctx  = context.Background()
+var ctx = context.Background()

--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -79,6 +79,21 @@ func (mr *ClientMockRecorder) CreateGroup(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroup", reflect.TypeOf((*Client)(nil).CreateGroup), arg0, arg1)
 }
 
+// CreateTarget mocks base method
+func (m *Client) CreateTarget(arg0 context.Context, arg1 zendesk.Target) (zendesk.Target, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTarget", arg0, arg1)
+	ret0, _ := ret[0].(zendesk.Target)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTarget indicates an expected call of CreateTarget
+func (mr *ClientMockRecorder) CreateTarget(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTarget", reflect.TypeOf((*Client)(nil).CreateTarget), arg0, arg1)
+}
+
 // CreateTicket mocks base method
 func (m *Client) CreateTicket(arg0 context.Context, arg1 zendesk.Ticket) (zendesk.Ticket, error) {
 	m.ctrl.T.Helper()
@@ -180,6 +195,20 @@ func (m *Client) DeleteGroup(arg0 context.Context, arg1 int64) error {
 func (mr *ClientMockRecorder) DeleteGroup(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroup", reflect.TypeOf((*Client)(nil).DeleteGroup), arg0, arg1)
+}
+
+// DeleteTarget mocks base method
+func (m *Client) DeleteTarget(arg0 context.Context, arg1 int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTarget", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTarget indicates an expected call of DeleteTarget
+func (mr *ClientMockRecorder) DeleteTarget(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTarget", reflect.TypeOf((*Client)(nil).DeleteTarget), arg0, arg1)
 }
 
 // DeleteTicketField mocks base method
@@ -343,6 +372,37 @@ func (m *Client) GetMultipleTickets(arg0 context.Context, arg1 []int64) ([]zende
 func (mr *ClientMockRecorder) GetMultipleTickets(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultipleTickets", reflect.TypeOf((*Client)(nil).GetMultipleTickets), arg0, arg1)
+}
+
+// GetTarget mocks base method
+func (m *Client) GetTarget(arg0 context.Context, arg1 int64) (zendesk.Target, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTarget", arg0, arg1)
+	ret0, _ := ret[0].(zendesk.Target)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTarget indicates an expected call of GetTarget
+func (mr *ClientMockRecorder) GetTarget(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTarget", reflect.TypeOf((*Client)(nil).GetTarget), arg0, arg1)
+}
+
+// GetTargets mocks base method
+func (m *Client) GetTargets(arg0 context.Context) ([]zendesk.Target, zendesk.Page, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTargets", arg0)
+	ret0, _ := ret[0].([]zendesk.Target)
+	ret1, _ := ret[1].(zendesk.Page)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetTargets indicates an expected call of GetTargets
+func (mr *ClientMockRecorder) GetTargets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTargets", reflect.TypeOf((*Client)(nil).GetTargets), arg0)
 }
 
 // GetTicket mocks base method
@@ -513,6 +573,21 @@ func (m *Client) UpdateGroup(arg0 context.Context, arg1 int64, arg2 zendesk.Grou
 func (mr *ClientMockRecorder) UpdateGroup(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGroup", reflect.TypeOf((*Client)(nil).UpdateGroup), arg0, arg1, arg2)
+}
+
+// UpdateTarget mocks base method
+func (m *Client) UpdateTarget(arg0 context.Context, arg1 int64, arg2 zendesk.Target) (zendesk.Target, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateTarget", arg0, arg1, arg2)
+	ret0, _ := ret[0].(zendesk.Target)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateTarget indicates an expected call of UpdateTarget
+func (mr *ClientMockRecorder) UpdateTarget(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTarget", reflect.TypeOf((*Client)(nil).UpdateTarget), arg0, arg1, arg2)
 }
 
 // UpdateTicketField mocks base method

--- a/zendesk/target.go
+++ b/zendesk/target.go
@@ -1,0 +1,135 @@
+package zendesk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Target is struct for target payload
+type Target struct {
+	URL       string     `json:"url,omitempty"`
+	ID        int64      `json:"id,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	Type      string     `json:"type"`
+	Title     string     `json:"title"`
+	Active    bool       `json:"active,omitempty"`
+	// email_target
+	Email   string `json:"email,omitempty"`
+	Subject string `json:"subject,omitempty"`
+	// http_target
+	TargetURL   string `json:"target_url,omitempty"`
+	Method      string `json:"method,omitempty"`
+	Username    string `json:"username,omitempty"`
+	Password    string `json:"password,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+}
+
+// Target an interface containing all of the target related zendesk methods
+type TargetAPI interface {
+	GetTargets(ctx context.Context) ([]Target, Page, error)
+	CreateTarget(ctx context.Context, ticketField Target) (Target, error)
+	GetTarget(ctx context.Context, ticketID int64) (Target, error)
+	UpdateTarget(ctx context.Context, ticketID int64, field Target) (Target, error)
+	DeleteTarget(ctx context.Context, ticketID int64) error
+}
+
+// Target fetches target list
+// ref: https://developer.zendesk.com/rest_api/docs/core/targets#list-targets
+func (z *Client) GetTargets(ctx context.Context) ([]Target, Page, error) {
+	var data struct {
+		Targets []Target `json:"targets"`
+		Page
+	}
+
+	body, err := z.get(ctx, "/targets.json")
+	if err != nil {
+		return []Target{}, Page{}, err
+	}
+
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return []Target{}, Page{}, err
+	}
+
+	return data.Targets, data.Page, nil
+}
+
+// CreateTarget creates new target
+// ref: https://developer.zendesk.com/rest_api/docs/core/targets#create-target
+func (z *Client) CreateTarget(ctx context.Context, target Target) (Target, error) {
+	var data, result struct {
+		Target Target `json:"target"`
+	}
+
+	data.Target = target
+
+	body, err := z.post(ctx, "/targets.json", data)
+	if err != nil {
+		return Target{}, err
+	}
+
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return Target{}, err
+	}
+
+	return result.Target, nil
+}
+
+// GetTarget gets a specified target
+// ref: https://developer.zendesk.com/rest_api/docs/support/targets#show-target
+func (z *Client) GetTarget(ctx context.Context, targetID int64) (Target, error) {
+	var result struct {
+		Target Target `json:"target"`
+	}
+
+	body, err := z.get(ctx, fmt.Sprintf("/targets/%d.json", targetID))
+
+	if err != nil {
+		return Target{}, err
+	}
+
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return Target{}, err
+	}
+
+	return result.Target, err
+}
+
+// UpdateTarget updates a field with the specified target
+// ref: https://developer.zendesk.com/rest_api/docs/support/targets#update-target
+func (z *Client) UpdateTarget(ctx context.Context, targetID int64, field Target) (Target, error) {
+	var result, data struct {
+		Target Target `json:"target"`
+	}
+
+	data.Target = field
+
+	body, err := z.put(ctx, fmt.Sprintf("/targets/%d.json", targetID), data)
+
+	if err != nil {
+		return Target{}, err
+	}
+
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return Target{}, err
+	}
+
+	return result.Target, err
+}
+
+// DeleteTarget deletes the specified target
+// ref: https://developer.zendesk.com/rest_api/docs/support/targets#delete-target
+func (z *Client) DeleteTarget(ctx context.Context, targetID int64) error {
+	err := z.delete(ctx, fmt.Sprintf("/targets/%d.json", targetID))
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/zendesk/target_test.go
+++ b/zendesk/target_test.go
@@ -1,0 +1,78 @@
+package zendesk
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetTargets(t *testing.T) {
+	mockAPI := newMockAPI(http.MethodGet, "targets.json")
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	targets, _, err := client.GetTargets(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get targets: %s", err)
+	}
+
+	if len(targets) != 2 {
+		t.Fatalf("expected length of targets is , but got %d", len(targets))
+	}
+}
+
+func TestGetTarget(t *testing.T) {
+	mockAPI := newMockAPI(http.MethodGet, "target.json")
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	target, err := client.GetTarget(ctx, 123)
+	if err != nil {
+		t.Fatalf("Failed to get targets: %s", err)
+	}
+
+	expectedID := int64(360000217439)
+	if target.ID != expectedID {
+		t.Fatalf("Returned target does not have the expected ID %d. Ticket id is %d", expectedID, target.ID)
+	}
+}
+
+func TestCreateTarget(t *testing.T) {
+	mockAPI := newMockAPIWithStatus(http.MethodPost, "target.json", http.StatusCreated)
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	_, err := client.CreateTarget(ctx, Target{})
+	if err != nil {
+		t.Fatalf("Failed to send request to create target: %s", err)
+	}
+}
+
+func TestUpdateTarget(t *testing.T) {
+	mockAPI := newMockAPIWithStatus(http.MethodPut, "target.json", http.StatusOK)
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	updatedField, err := client.UpdateTarget(ctx, int64(1234), Target{})
+	if err != nil {
+		t.Fatalf("Failed to send request to create target: %s", err)
+	}
+
+	expectedID := int64(360000217439)
+	if updatedField.ID != expectedID {
+		t.Fatalf("Updated field %v did not have expected id %d", updatedField, expectedID)
+	}
+}
+
+func TestDeleteTarget(t *testing.T) {
+	mockAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+		w.Write(nil)
+	}))
+
+	c := newTestClient(mockAPI)
+	err := c.DeleteTarget(ctx, 1234)
+	if err != nil {
+		t.Fatalf("Failed to delete target: %s", err)
+	}
+}


### PR DESCRIPTION
Implemented initial support for operating on targets. Only `email_target` and `http_target` are currently supported, but adding support for other target types is relatively straightforward.