### PR TITLE
Issue #122 Forgot to add nil and bool types.

### DIFF
--- a/fixture/GET/ticket_custom_field.json
+++ b/fixture/GET/ticket_custom_field.json
@@ -42,6 +42,14 @@
       {
         "id": 360005657121,
         "value": ["list", "of", "values"]
+      },
+      {
+        "id": 360005657122,
+        "value": null
+      },
+      {
+        "id": 360005657123,
+        "value": true
       }
     ],
     "satisfaction_rating": null,

--- a/zendesk/ticket.go
+++ b/zendesk/ticket.go
@@ -26,7 +26,7 @@ func (cf *CustomField) UnmarshalJSON(data []byte) error {
 	cf.ID = int64(temp["id"].(float64))
 
 	switch v := temp["value"].(type) {
-	case string:
+	case string, nil, bool:
 		cf.Value = v
 	case []interface{}:
 		var list []string

--- a/zendesk/ticket_test.go
+++ b/zendesk/ticket_test.go
@@ -102,6 +102,12 @@ func TestGetTicketWithCustomFields(t *testing.T) {
 					t.Fatalf("Expected to find %s in custom fields", v)
 				}
 			}
+		case nil:
+			/* Do nothing */
+		case bool:
+			if !cf.Value.(bool) {
+				t.Fatal("Expected to find true in custom fields")
+			}
 		default:
 			t.Fatalf("Invalid value type in custom field:  %v.", cf)
 		}


### PR DESCRIPTION
Upon further testing it was revealed that Zendesk does return nil and
boolean values for custom fields. Numeric and decimal type custom
fields are returned as strings.

This is a breaking issue for v0.4.2 since upon ticket creation Zendesk returns the created ticket itself, which may be full of nils from empty custom fields.