### PR TITLE
Add TicketComment functionality

### DIFF
--- a/fixture/GET/ticket_comments.json
+++ b/fixture/GET/ticket_comments.json
@@ -1,0 +1,26 @@
+{
+  "comments": [
+	  {
+		  "id": 2,
+		  "type": "Comment",
+		  "body": "Mail to create fixture ticket for testing",
+		  "html_body": "",
+		  "plain_body": "",
+		  "public": true,
+		  "author_id": 377922500012,
+		  "attachments": [],
+		  "created_at": "2019-06-03T01:23:47Z"
+	  },
+	  {
+		  "id": 3,
+		  "type": "Comment",
+		  "body": "Mail to create fixture ticket for testing",
+		  "html_body": "",
+		  "plain_body": "",
+		  "public": true,
+		  "author_id": 377922500012,
+		  "attachments": [],
+		  "created_at": "2019-06-03T02:23:47Z"
+	  }
+  ]
+}

--- a/fixture/PUT/ticket.json
+++ b/fixture/PUT/ticket.json
@@ -1,0 +1,58 @@
+{
+  "ticket": {
+    "url": "https://d3v-terraform-provider.zendesk.com/api/v2/tickets/2.json",
+    "id": 2,
+    "external_id": null,
+    "via": {
+      "channel": "email",
+      "source": {
+        "from": {
+          "address": "nukosuke@lavabit.com",
+          "name": "Yosuke Tamura"
+        },
+        "to": {
+          "name": "Terraform Zendesk provider",
+          "address": "support@d3v-terraform-provider.zendesk.com"
+        },
+        "rel": null
+      }
+    },
+    "created_at": "2019-06-03T02:23:47Z",
+    "updated_at": "2019-06-05T01:13:24Z",
+    "type": null,
+    "subject": "Mail to create fixture ticket for testing",
+    "raw_subject": "Mail to create fixture ticket for testing",
+    "description": "Mail to create fixture ticket for testing\n\nnukosuke (●ↀ ω ↀ●)",
+    "priority": null,
+    "status": "solved",
+    "recipient": "support@d3v-terraform-provider.zendesk.com",
+    "requester_id": 377922500012,
+    "submitter_id": 377922500012,
+    "assignee_id": 377922500012,
+    "organization_id": 360363695492,
+    "group_id": 360004077472,
+    "collaborator_ids": [
+      377922500012
+    ],
+    "follower_ids": [
+      377922500012
+    ],
+    "email_cc_ids": [],
+    "forum_topic_id": null,
+    "problem_id": null,
+    "has_incidents": false,
+    "is_public": true,
+    "due_at": null,
+    "tags": [],
+    "custom_fields": [],
+    "satisfaction_rating": null,
+    "sharing_agreement_ids": [],
+    "fields": [],
+    "followup_ids": [],
+    "ticket_form_id": 360000389592,
+    "brand_id": 360002256672,
+    "satisfaction_probability": null,
+    "allow_channelback": false,
+    "allow_attachments": true
+  }
+}

--- a/zendesk/ticket.go
+++ b/zendesk/ticket.go
@@ -102,13 +102,6 @@ type Ticket struct {
 	// TODO: TicketAudit (POST only) #126
 }
 
-// TODO: This is temporary struct for ticket support. #125
-//       Need to make it into correct TicketComment structure.
-//       https://developer.zendesk.com/rest_api/docs/support/ticket_comments
-type TicketComment struct {
-	Body string `json:"body"`
-}
-
 type TicketListOptions struct {
 	PageOptions
 

--- a/zendesk/ticket_comment.go
+++ b/zendesk/ticket_comment.go
@@ -1,0 +1,87 @@
+package zendesk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// TicketComment is a struct for ticket comment payload
+// Via and Metadata are currently unused
+// https://developer.zendesk.com/rest_api/docs/support/ticket_comments
+type TicketComment struct {
+	ID          int64        `json:"id,omitempty"`
+	Type        string       `json:"type,omitempty"`
+	Body        string       `json:"body,omitempty"`
+	HTMLBody    string       `json:"html_body,omitempty"`
+	PlainBody   string       `json:"plain_body,omitempty"`
+	Public      *bool        `json:"public,omitempty"`
+	AuthorID    int64        `json:"author_id,omitempty"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+	CreatedAt   time.Time    `json:"created_at,omitempty"`
+}
+
+// NewPublicComment generates and returns a new TicketComment
+func NewPublicTicketComment(body string, authorID int64) TicketComment {
+	public := true
+
+	return TicketComment{
+		Body:     body,
+		Public:   &public,
+		AuthorID: authorID,
+	}
+}
+
+// NewPrivateComment generates and returns a new private TicketComment
+func NewPrivateTicketComment(body string, authorID int64) TicketComment {
+	public := false
+
+	return TicketComment{
+		Body:     body,
+		Public:   &public,
+		AuthorID: authorID,
+	}
+}
+
+// CreateTicketComment creates a comment on a ticket
+//
+// ref: https://developer.zendesk.com/rest_api/docs/support/ticket_comments#create-ticket-comment
+func (z *Client) CreateTicketComment(ctx context.Context, ticketID int64, ticketComment TicketComment) error {
+	type comment struct {
+		Ticket struct {
+			TicketComment TicketComment `json:"comment"`
+		} `json:"ticket"`
+	}
+
+	data := &comment{}
+	data.Ticket.TicketComment = ticketComment
+
+	_, err := z.put(ctx, fmt.Sprintf("/tickets/%d.json", ticketID), data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ListTicketComments gets a list of comment for a specified ticket
+//
+// ref: https://developer.zendesk.com/rest_api/docs/support/ticket_comments#list-comments
+func (z *Client) ListTicketComments(ctx context.Context, ticketID int64) ([]TicketComment, error) {
+	var result struct {
+		TicketComments []TicketComment `json:"comments"`
+	}
+
+	body, err := z.get(ctx, fmt.Sprintf("/tickets/%d/comments.json", ticketID))
+	if err != nil {
+		return []TicketComment{}, err
+	}
+
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return []TicketComment{}, err
+	}
+
+	return result.TicketComments, err
+}

--- a/zendesk/ticket_comment_test.go
+++ b/zendesk/ticket_comment_test.go
@@ -1,0 +1,53 @@
+package zendesk
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewPublicTicketComment(t *testing.T) {
+	publicComment := NewPublicTicketComment("public comment", 12345)
+
+	// Both true and nil are public comments
+	if *publicComment.Public == false {
+		t.Fatalf("Returned comment is not marked as public. Comment public is %v", *publicComment.Public)
+	}
+}
+
+func TestNewPrivateTicketComment(t *testing.T) {
+	privateComment := NewPrivateTicketComment("private comment", 12345)
+
+	// Both true and nil are public comments
+	if *privateComment.Public != false {
+		t.Fatalf("Returned comment is not marked as private. Comment public is %v", *privateComment.Public)
+	}
+}
+
+func TestCreateTicketComment(t *testing.T) {
+	mockAPI := newMockAPI(http.MethodPut, "ticket.json")
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	publicComment := NewPublicTicketComment("public comment", 12345)
+
+	err := client.CreateTicketComment(ctx, 2, publicComment)
+	if err != nil {
+		t.Fatalf("Failed to create ticket comment: %s", err)
+	}
+}
+
+func TestListTicketComments(t *testing.T) {
+	mockAPI := newMockAPI(http.MethodGet, "ticket_comments.json")
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	ticketComments, err := client.ListTicketComments(ctx, 2)
+	if err != nil {
+		t.Fatalf("Failed to list ticket comments: %s", err)
+	}
+
+	expectedLength := 2
+	if len(ticketComments) != expectedLength {
+		t.Fatalf("Returned ticket comments does not have the expected length %d. Ticket comments length is %d", expectedLength, len(ticketComments))
+	}
+}


### PR DESCRIPTION
This PR contributes to #125 by adding some basic ticket comment support. I needed this for a project and noticed this functionality doesn't exist. I figured I might as well contribute upstream while I'm at it!

## Note regarding `Public` attribute

This is a potential gotcha that requires an odd solution.

If we use `omitempty` on that attribute, any TicketComments that have `Public: false` will be filtered out causing ALL comments to be public. Alternatively, if we remove that flag, the default for the package would be private comments which is not inline with the Zendesk API. Using `*bool` is a good compromise so we can have 3 states (`true`/`false`/`nil`). We'd have a default of public comments while still offering private ones.

The downside is confusion with generating new TicketComment structs. I added some utility functions (`NewPublicTicketComment` and `NewPrivateTicketComment`) to make this easier to work with for an outside party.

