### PR TITLE
Adds upload field for comments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nukosuke/go-zendesk
+module github.com/lagerstrom/go-zendesk
 
 require (
 	github.com/golang/mock v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/lagerstrom/go-zendesk
+module github.com/nukosuke/go-zendesk
 
 require (
 	github.com/golang/mock v1.4.3
 	github.com/google/go-querystring v1.0.0
 )
 
-go 1.14
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/google/go-querystring v1.0.0
 )
 
-go 1.13
+go 1.14

--- a/zendesk/ticket_comment.go
+++ b/zendesk/ticket_comment.go
@@ -20,6 +20,7 @@ type TicketComment struct {
 	AuthorID    int64        `json:"author_id,omitempty"`
 	Attachments []Attachment `json:"attachments,omitempty"`
 	CreatedAt   time.Time    `json:"created_at,omitempty"`
+	Uploads     []string     `json:"uploads"`
 }
 
 // NewPublicComment generates and returns a new TicketComment

--- a/zendesk/ticket_comment.go
+++ b/zendesk/ticket_comment.go
@@ -20,7 +20,7 @@ type TicketComment struct {
 	AuthorID    int64        `json:"author_id,omitempty"`
 	Attachments []Attachment `json:"attachments,omitempty"`
 	CreatedAt   time.Time    `json:"created_at,omitempty"`
-	Uploads     []string     `json:"uploads"`
+	Uploads     []string     `json:"uploads,omitempty"`
 }
 
 // NewPublicComment generates and returns a new TicketComment


### PR DESCRIPTION
To have attachement attached to tickets the `uploads` field need to be present. 

See this article https://support.zendesk.com/hc/en-us/articles/223137947-Attaching-files-to-tickets-via-API