### PR TITLE
Unmarshal TriggerCondition Value to interface{}

### DIFF
--- a/zendesk/trigger.go
+++ b/zendesk/trigger.go
@@ -11,9 +11,9 @@ import (
 //
 // ref: https://developer.zendesk.com/rest_api/docs/core/triggers#conditions-reference
 type TriggerCondition struct {
-	Field    string `json:"field"`
-	Operator string `json:"operator"`
-	Value    string `json:"value"`
+	Field    string      `json:"field"`
+	Operator string      `json:"operator"`
+	Value    interface{} `json:"value"`
 }
 
 // TriggerAction is zendesk trigger action


### PR DESCRIPTION
Values inside `TriggerCondition` can be any JSON value: `number`, `string`, `boolean` and even `null`. Therefore we need the `Value` field to be an `interface{}`. 

Fixes #177