### PR TITLE
add nil check to z.credential

### DIFF
--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -216,7 +216,9 @@ func (z *Client) delete(ctx context.Context, path string) error {
 func (z *Client) prepareRequest(ctx context.Context, req *http.Request) *http.Request {
 	out := req.WithContext(ctx)
 	z.includeHeaders(out)
-	out.SetBasicAuth(z.credential.Email(), z.credential.Secret())
+	if z.credential != nil {
+		out.SetBasicAuth(z.credential.Email(), z.credential.Secret())
+	}
 
 	return out
 }


### PR DESCRIPTION
I had a problem when I wanted to authenticate using OAuth2 token as follows, so I dealt with it.

```go
	ctx := context.Background()
	ts := oauth2.StaticTokenSource(
		&oauth2.Token{AccessToken: os.Getenv("ZENDESK_OAUTH2_TOKEN")},
	)
	tc := oauth2.NewClient(ctx, ts)

	z, _ := zendesk.NewClient(tc)

	ifz.SetSubdomain(os.Getenv("ZENDESK_SUBDOMAIN"))

	ticket, _ := z.GetTicket(ctx, int64(2))
```

got
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
```

Please review.