### PR TITLE
Bugfix json-marshal collaborators in Ticket

### DIFF
--- a/zendesk/collaborators.go
+++ b/zendesk/collaborators.go
@@ -70,7 +70,7 @@ func (c *Collaborators) Append(i interface{}) error {
 }
 
 // MarshalJSON is marshaller for Collaborators
-func (c *Collaborators) MarshalJSON() ([]byte, error) {
+func (c Collaborators) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.collaborators)
 }
 

--- a/zendesk/collaborators_test.go
+++ b/zendesk/collaborators_test.go
@@ -1,6 +1,7 @@
 package zendesk
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -45,5 +46,21 @@ func TestCanBeMarshalled(t *testing.T) {
 
 	if string(out) != collaboratorListJSON {
 		t.Fatalf("Json output %s did not match expected output %s", out, collaboratorListJSON)
+	}
+}
+
+func TestCanBeRemarshalled(t *testing.T) {
+	var src, dst Collaborators
+	marshalled, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("Marshalling returned an error %v", err)
+	}
+	err = json.Unmarshal(marshalled, &dst)
+	if err != nil {
+		t.Fatalf("Unmarshal returned an error %v", err)
+	}
+
+	if !reflect.DeepEqual(src, dst) {
+		t.Fatalf("remarshalling is inconsistent")
 	}
 }

--- a/zendesk/ticket_test.go
+++ b/zendesk/ticket_test.go
@@ -229,3 +229,22 @@ func TestDeleteTicket(t *testing.T) {
 		t.Fatalf("Failed to delete ticket field: %s", err)
 	}
 }
+
+func TestTicketMarshalling(t *testing.T) {
+	var src, dst Ticket
+
+	marshalled, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("Failed to json-marshal ticket: %v", err)
+	}
+
+	err = json.Unmarshal(marshalled, &dst)
+	if err != nil {
+		t.Fatalf("Failed to json-unmarshal ticket: %v", err)
+	}
+
+	if !reflect.DeepEqual(src, dst) {
+		t.Fatalf("remarshalling is inconsistent")
+	}
+
+}


### PR DESCRIPTION
Many thanks for the library!

Here's a PR to fix a small bug when json-marshalling a `Ticket`.

This happens, e.g. when creating a Ticket in [ticket.go:242](https://github.com/nukosuke/go-zendesk/blob/master/zendesk/ticket.go#L242)
which marshals the passed Ticket in [zendesk.go:117](https://github.com/nukosuke/go-zendesk/blob/0dfede2ee6f18a8c2586ccba2ede2bf9b4b042ac/zendesk/zendesk.go#L117)
The json sent to the server is then something like this:
```json
{
  "ticket": {
    "//": "...",
    "collaborators": {},
    "//": "...",
  }
}
```
Although it should be `"collaborators" : []` because it's clearly a list. 
The reason is, that `json.Marshal(...)` is called on a value of `Ticket` instead of a pointer, i.e. the function `func (c * Collaborators) MarshalJSON() ([]byte, error)` is never called.

In production there is no problem because Zendesk tolerates the data.
In our application however we mock Zendesk's http interface for unit testing. In the mock we'd like to `json.Unmarshal` the received data into a `Ticket` to send it back to the caller. This fails with `json: cannot unmarshal object into Go struct field Ticket.ticket.collaborators of type []interface {}`. 
I'd like to fix that.