### PR TITLE
expose Get and Put methods in API interface

### DIFF
--- a/zendesk/api.go
+++ b/zendesk/api.go
@@ -7,6 +7,7 @@ package zendesk
 type API interface {
 	AutomationAPI
 	AttachmentAPI
+	BaseAPI
 	BrandAPI
 	DynamicContentAPI
 	GroupAPI

--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -458,6 +458,21 @@ func (mr *ClientMockRecorder) DeleteUpload(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUpload", reflect.TypeOf((*Client)(nil).DeleteUpload), arg0, arg1)
 }
 
+// Get mocks base method.
+func (m *Client) Get(arg0 context.Context, arg1 string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *ClientMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Client)(nil).Get), arg0, arg1)
+}
+
 // GetAllTicketAudits mocks base method.
 func (m *Client) GetAllTicketAudits(arg0 context.Context, arg1 zendesk.CursorOption) ([]zendesk.TicketAudit, zendesk.Cursor, error) {
 	m.ctrl.T.Helper()
@@ -1089,6 +1104,21 @@ func (m *Client) ListTicketComments(arg0 context.Context, arg1 int64) ([]zendesk
 func (mr *ClientMockRecorder) ListTicketComments(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTicketComments", reflect.TypeOf((*Client)(nil).ListTicketComments), arg0, arg1)
+}
+
+// Post mocks base method.
+func (m *Client) Post(arg0 context.Context, arg1 string, arg2 interface{}) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Post", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Post indicates an expected call of Post.
+func (mr *ClientMockRecorder) Post(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*Client)(nil).Post), arg0, arg1, arg2)
 }
 
 // Search mocks base method.

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -24,13 +24,21 @@ var defaultHeaders = map[string]string{
 
 var subdomainRegexp = regexp.MustCompile("^[a-z0-9][a-z0-9-]+[a-z0-9]$")
 
-// Client of Zendesk API
-type Client struct {
-	baseURL    *url.URL
-	httpClient *http.Client
-	credential Credential
-	headers    map[string]string
-}
+type (
+	// Client of Zendesk API
+	Client struct {
+		baseURL    *url.URL
+		httpClient *http.Client
+		credential Credential
+		headers    map[string]string
+	}
+
+	// BaseAPI encapsulates base methods for zendesk client
+	BaseAPI interface {
+		Get(ctx context.Context, path string) ([]byte, error)
+		Post(ctx context.Context, path string, data interface{}) ([]byte, error)
+	}
+)
 
 // NewClient creates new Zendesk API client
 func NewClient(httpClient *http.Client) (*Client, error) {


### PR DESCRIPTION
Previous commit added methods to query not-yet-implemented API endpoints (https://github.com/nukosuke/go-zendesk/commit/67acb1580313dd11b0a60b13ff39dcc909aad617), but didn't expose these in the client interface so they are still not callable. Adding them here.

Tested this locally and was able to query an arbitrary endpoint