### PR TITLE
Allow omitempty to work for DueAt time.Time

### DIFF
--- a/zendesk/ticket.go
+++ b/zendesk/ticket.go
@@ -69,7 +69,7 @@ type Ticket struct {
 	ForumTopicID    int64         `json:"forum_topic_id,omitempty"`
 	ProblemID       int64         `json:"problem_id,omitempty"`
 	HasIncidents    bool          `json:"has_incidents,omitempty"`
-	DueAt           time.Time     `json:"due_at,omitempty"`
+	DueAt           *time.Time    `json:"due_at,omitempty"`
 	Tags            []string      `json:"tags,omitempty"`
 	CustomFields    []CustomField `json:"custom_fields,omitempty"`
 


### PR DESCRIPTION
`omitempty` doesnt work on empty times unless they're pointers.

We don't have `DueAt` set on our tickets and `omitempty` on `time.Time` only works when its a pointer, as `isZero`  returns `false` for an empty `time.Time{}` where as `isZero` will return `true` when a pointer is not existent.

if `DueAt` is not a pointer, then when I get the ticket back from the API, it'll set `DueAt` to `0001-01-01 00:00:00 +0000 UTC` and similarly, if i don't set it on a `Ticket` i update, then it'll send it to the API as `0001-01-01 00:00:00 +0000 UTC`.

This patch resolves this issue. 