### PR TITLE
Add support for Bearer tokens

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ build: off
 clone_folder: c:\github.com\nukosuke\go-zendesk
 
 environment:
-  GOPATH: c:\gopath
+  GOPATH: c:\go119
   GO111MODULE: on
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ cache:
   - '%LocalAppData%\go-build'
   - '%GOPATH%\pkg\mod'
 
-stack: go 1.11
+stack: go 1.19
 
 install:
   - go mod download

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,10 @@ environment:
   GOPATH: c:\go119
   GO111MODULE: on
 
-cache:
-  - '%LocalAppData%\go-build'
-  - '%GOPATH%\pkg\mod'
+# temporarily clearing cache to get newer version of Go
+#cache:
+#  - '%LocalAppData%\go-build'
+#  - '%GOPATH%\pkg\mod'
 
 stack: go 1.19
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,13 +3,12 @@ build: off
 clone_folder: c:\github.com\nukosuke\go-zendesk
 
 environment:
-  GOPATH: c:\go119
+  GOPATH: c:\gopath
   GO111MODULE: on
 
-# temporarily clearing cache to get newer version of Go
-#cache:
-#  - '%LocalAppData%\go-build'
-#  - '%GOPATH%\pkg\mod'
+cache:
+  - '%LocalAppData%\go-build'
+  - '%GOPATH%\pkg\mod'
 
 stack: go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/nukosuke/go-zendesk
 
+go 1.19
+
 require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-querystring v1.1.0
 )
-
-go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nukosuke/go-zendesk
 
-go 1.19
+go 1.15
 
 require (
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -27,4 +27,5 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -27,5 +27,4 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/zendesk/credential.go
+++ b/zendesk/credential.go
@@ -65,6 +65,7 @@ func (c APITokenCredential) Bearer() bool {
 	return false
 }
 
+// BearerTokenCredential can be used to authenticate OAuth tokens issued by Zendesk.
 type BearerTokenCredential struct {
 	token string
 }

--- a/zendesk/credential.go
+++ b/zendesk/credential.go
@@ -4,6 +4,7 @@ package zendesk
 type Credential interface {
 	Email() string
 	Secret() string
+	Bearer() bool
 }
 
 // BasicAuthCredential is type of credential for Basic authentication
@@ -30,6 +31,11 @@ func (c BasicAuthCredential) Secret() string {
 	return c.password
 }
 
+// Bearer is accessor which returns whether the credential is a bearer token
+func (c BasicAuthCredential) Bearer() bool {
+	return false
+}
+
 // APITokenCredential is type of credential for API token authentication
 type APITokenCredential struct {
 	email    string
@@ -52,4 +58,34 @@ func (c APITokenCredential) Email() string {
 // Secret is accessor which returns API token
 func (c APITokenCredential) Secret() string {
 	return c.apiToken
+}
+
+// Bearer is accessor which returns whether the credential is a bearer token
+func (c APITokenCredential) Bearer() bool {
+	return false
+}
+
+type BearerTokenCredential struct {
+	token string
+}
+
+// NewBearerTokenCredential returns a pointer to a new BearerTokenCredential. Bearer
+// tokens are issued by Zendesk OAuth clients.
+func NewBearerTokenCredential(token string) *BearerTokenCredential {
+	return &BearerTokenCredential{token: token}
+}
+
+// Email is accessor which returns email address
+func (c BearerTokenCredential) Email() string {
+	return ""
+}
+
+// Secret is accessor which returns API token
+func (c BearerTokenCredential) Secret() string {
+	return c.token
+}
+
+// Bearer is accessor which returns whether the credential is a bearer token
+func (c BearerTokenCredential) Bearer() bool {
+	return true
 }

--- a/zendesk/credential_test.go
+++ b/zendesk/credential_test.go
@@ -11,6 +11,9 @@ func TestNewBasicAuthCredential(t *testing.T) {
 	if cred.Secret() != "password" {
 		t.Fatalf("BasicAuthCredential: secret not match")
 	}
+	if cred.Bearer() {
+		t.Fatalf("BasicAuthCredential: not a bearer token")
+	}
 }
 
 func TestNewAPITokenCredential(t *testing.T) {
@@ -21,5 +24,22 @@ func TestNewAPITokenCredential(t *testing.T) {
 	}
 	if cred.Secret() != "apitoken" {
 		t.Fatalf("APITokenCredential: secret not match")
+	}
+	if cred.Bearer() {
+		t.Fatalf("APITokenCredential: not a bearer token")
+	}
+}
+
+func TestNewBearerTokenCredential(t *testing.T) {
+	cred := NewBearerTokenCredential("apitoken")
+
+	if cred.Email() != "" {
+		t.Fatalf("BearerTokenCredential: email not match")
+	}
+	if cred.Secret() != "apitoken" {
+		t.Fatalf("BearerTokenCredential: secret not match")
+	}
+	if !cred.Bearer() {
+		t.Fatalf("BearerTokenCredential: is a bearer token")
 	}
 }

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -228,7 +228,11 @@ func (z *Client) prepareRequest(ctx context.Context, req *http.Request) *http.Re
 	out := req.WithContext(ctx)
 	z.includeHeaders(out)
 	if z.credential != nil {
-		out.SetBasicAuth(z.credential.Email(), z.credential.Secret())
+		if z.credential.Bearer() {
+			out.Header.Add("Authorization", "Bearer "+z.credential.Secret())
+		} else {
+			out.SetBasicAuth(z.credential.Email(), z.credential.Secret())
+		}
 	}
 
 	return out

--- a/zendesk/zendesk_test.go
+++ b/zendesk/zendesk_test.go
@@ -3,6 +3,7 @@ package zendesk
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -23,7 +24,7 @@ func fixture(filename string) string {
 }
 
 func readFixture(filename string) []byte {
-	bytes, err := os.ReadFile(fixture(filename))
+	bytes, err := ioutil.ReadFile(fixture(filename))
 	if err != nil {
 		fmt.Printf("Failed to read fixture. Check the path: %s", err)
 		os.Exit(1)
@@ -172,7 +173,7 @@ func TestGetFailureCanReadErrorBody(t *testing.T) {
 	}
 
 	body := clientErr.Body()
-	_, err = io.ReadAll(body)
+	_, err = ioutil.ReadAll(body)
 	if err != nil {
 		t.Fatal("Client received error while reading client body")
 	}

--- a/zendesk/zendesk_test.go
+++ b/zendesk/zendesk_test.go
@@ -2,7 +2,6 @@ package zendesk
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"


### PR DESCRIPTION
Zendesk OAuth tokens must use the Bearer prefix.

Question to maintainers: Can we bump the go.mod to 1.19? I tried doing it in my commits, but I think the appveyor build system might be using a Go binary of a lower version, I couldn't quite figure it out.