### PR TITLE
Add GetWebhookSigningSecret

### DIFF
--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -1239,6 +1239,21 @@ func (mr *ClientMockRecorder) GetWebhook(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWebhook", reflect.TypeOf((*Client)(nil).GetWebhook), arg0, arg1)
 }
 
+// GetWebhookSigningSecret mocks base method.
+func (m *Client) GetWebhookSigningSecret(arg0 context.Context, arg1 string) (*zendesk.WebhookSigningSecret, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWebhookSigningSecret", arg0, arg1)
+	ret0, _ := ret[0].(*zendesk.WebhookSigningSecret)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWebhookSigningSecret indicates an expected call of GetWebhookSigningSecret.
+func (mr *ClientMockRecorder) GetWebhookSigningSecret(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWebhookSigningSecret", reflect.TypeOf((*Client)(nil).GetWebhookSigningSecret), arg0, arg1)
+}
+
 // ListInstallations mocks base method.
 func (m *Client) ListInstallations(arg0 context.Context) ([]zendesk.AppInstallation, error) {
 	m.ctrl.T.Helper()

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -43,6 +43,7 @@ type WebhookAPI interface {
 	GetWebhook(ctx context.Context, webhookID string) (*Webhook, error)
 	UpdateWebhook(ctx context.Context, webhookID string, hook *Webhook) error
 	DeleteWebhook(ctx context.Context, webhookID string) error
+	GetWebhookSigningSecret(ctx context.Context, webhookID string) (*WebhookSigningSecret, error)
 }
 
 // CreateWebhook creates new webhook.
@@ -114,4 +115,25 @@ func (z *Client) DeleteWebhook(ctx context.Context, webhookID string) error {
 	}
 
 	return nil
+}
+
+// GetWebhookSigningSecret gets the signing secret of specified webhook.
+//
+// https://developer.zendesk.com/api-reference/event-connectors/webhooks/webhooks/#show-webhook-signing-secret
+func (z *Client) GetWebhookSigningSecret(ctx context.Context, webhookID string) (*WebhookSigningSecret, error) {
+	var result struct {
+		SigningSecret *WebhookSigningSecret `json:"signing_secret"`
+	}
+
+	body, err := z.get(ctx, fmt.Sprintf("/webhooks/%s/signing_secret", webhookID))
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.SigningSecret, nil
 }


### PR DESCRIPTION
The result of GetWebhook doesn't contain the signing secret. This isn't a problem of this package, it's simply that Zendesk API doesn't return the signing secret field in the payload. In order to receive it it's necessary to call a separate endpoint.