### PR TITLE
return value type of Error on NewError

### DIFF
--- a/zendesk/error.go
+++ b/zendesk/error.go
@@ -17,8 +17,8 @@ type Error struct {
 // NewError is a function to initialize the Error type. This function will be useful
 // for unit testing and mocking purposes in the client side
 // to test their behavior by the API response.
-func NewError(body []byte, resp *http.Response) *Error {
-	return &Error{
+func NewError(body []byte, resp *http.Response) Error {
+	return Error{
 		body: body,
 		resp: resp,
 	}


### PR DESCRIPTION
Turns out that the wrapped error from each API is a value type of `Error`. Then we need to make the `NewError` returns the same type.