### PR TITLE
feat: add organization tickets function

### DIFF
--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -915,6 +915,22 @@ func (mr *ClientMockRecorder) GetOrganizationTags(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizationTags", reflect.TypeOf((*Client)(nil).GetOrganizationTags), arg0, arg1)
 }
 
+// GetOrganizationTickets mocks base method.
+func (m *Client) GetOrganizationTickets(arg0 context.Context, arg1 int64, arg2 *zendesk.TicketListOptions) ([]zendesk.Ticket, zendesk.Page, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrganizationTickets", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]zendesk.Ticket)
+	ret1, _ := ret[1].(zendesk.Page)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOrganizationTickets indicates an expected call of GetOrganizationTickets.
+func (mr *ClientMockRecorder) GetOrganizationTickets(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizationTickets", reflect.TypeOf((*Client)(nil).GetOrganizationTickets), arg0, arg1, arg2)
+}
+
 // GetOrganizationUsers mocks base method.
 func (m *Client) GetOrganizationUsers(arg0 context.Context, arg1 int64, arg2 *zendesk.UserListOptions) ([]zendesk.User, zendesk.Page, error) {
 	m.ctrl.T.Helper()

--- a/zendesk/ticket_test.go
+++ b/zendesk/ticket_test.go
@@ -34,6 +34,29 @@ func TestGetTickets(t *testing.T) {
 	}
 }
 
+func TestGetOrganizationTickets(t *testing.T) {
+	mockAPI := newMockAPI(http.MethodGet, "tickets.json")
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	tickets, _, err := client.GetOrganizationTickets(ctx, 360363695492, &TicketListOptions{
+		PageOptions: PageOptions{
+			Page:    1,
+			PerPage: 10,
+		},
+		SortBy:    "created_at",
+		SortOrder: "asc",
+	})
+	if err != nil {
+		t.Fatalf("Failed to get tickets: %s", err)
+	}
+
+	expectedLength := 2
+	if len(tickets) != expectedLength {
+		t.Fatalf("Returned tickets does not have the expected length %d. Tickets length is %d", expectedLength, len(tickets))
+	}
+}
+
 func TestGetTicket(t *testing.T) {
 	mockAPI := newMockAPI(http.MethodGet, "ticket.json")
 	client := newTestClient(mockAPI)


### PR DESCRIPTION
Use the get tickets API but with the organization id parameter.

https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#list-tickets
(GET /api/v2/organizations/{organization_id}/tickets)