### PR TITLE
fix: add include users in ticket comments API

### DIFF
--- a/zendesk/ticket_comment.go
+++ b/zendesk/ticket_comment.go
@@ -116,6 +116,7 @@ type ListTicketCommentsOptions struct {
 type ListTicketCommentsResult struct {
 	TicketComments []TicketComment      `json:"comments"`
 	Meta           CursorPaginationMeta `json:"meta"`
+	Users          []User               `json:"users"`
 }
 
 // ListTicketComments gets a list of comment for a specified ticket


### PR DESCRIPTION
The include users didn't returned the list of users as described in the documentation:
https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_comments/#parameters
