### PR TITLE
Custom objects v2

### DIFF
--- a/zendesk/api.go
+++ b/zendesk/api.go
@@ -33,6 +33,7 @@ type API interface {
 	UserFieldAPI
 	ViewAPI
 	WebhookAPI
+	CustomObjectAPI
 }
 
 var _ API = (*Client)(nil)

--- a/zendesk/custom_object.go
+++ b/zendesk/custom_object.go
@@ -8,16 +8,16 @@ import (
 )
 
 type CustomObjectRecord struct {
-	Url                string                 `json:"url"`
-	Name               string                 `json:"name"`
-	ID                 string                 `json:"id"`
+	Url                string                 `json:"url,omitempty"`
+	Name               string                 `json:"name,omitempty"`
+	ID                 string                 `json:"id,omitempty"`
 	CustomObjectKey    string                 `json:"custom_object_key"`
 	CustomObjectFields map[string]interface{} `json:"custom_object_fields" binding:"required"`
-	CreatedByUserID    string                 `json:"created_by_user_id"`
-	UpdatedByUserID    string                 `json:"updated_by_user_id"`
-	CreatedAt          time.Time              `json:"created_at"`
-	UpdatedAt          time.Time              `json:"updated_at"`
-	ExternalID         string                 `json:"external_id"`
+	CreatedByUserID    string                 `json:"created_by_user_id,omitempty"`
+	UpdatedByUserID    string                 `json:"updated_by_user_id,omitempty"`
+	CreatedAt          time.Time              `json:"created_at,omitempty"`
+	UpdatedAt          time.Time              `json:"updated_at,omitempty"`
+	ExternalID         string                 `json:"external_id,omitempty"`
 }
 
 // CustomObjectAPI an interface containing all custom object related methods

--- a/zendesk/custom_object.go
+++ b/zendesk/custom_object.go
@@ -1,0 +1,85 @@
+package zendesk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type CustomObjectRecord struct {
+	Url                string                 `json:"url"`
+	Name               string                 `json:"name"`
+	ID                 string                 `json:"id"`
+	CustomObjectKey    string                 `json:"custom_object_key"`
+	CustomObjectFields map[string]interface{} `json:"custom_object_fields"`
+	CreatedByUserID    string                 `json:"created_by_user_id"`
+	UpdatedByUserID    string                 `json:"updated_by_user_id"`
+	CreatedAt          time.Time              `json:"created_at"`
+	UpdatedAt          time.Time              `json:"updated_at"`
+	ExternalID         string                 `json:"external_id"`
+}
+
+// CustomObjectAPI an interface containing all custom object related methods
+type CustomObjectAPI interface {
+	CreateCustomObjectRecord(
+		ctx context.Context, record CustomObjectRecord, customObjectKey string) (CustomObjectRecord, error)
+	SearchCustomObjectRecords(
+		ctx context.Context,
+		customObjectKey string,
+		opts *CustomObjectListOptions,
+	) ([]CustomObjectRecord, Page, error)
+}
+
+// CustomObjectListOptions custom object search options
+type CustomObjectListOptions struct {
+	PageOptions
+	Name string `url:"name"`
+}
+
+// CreateCustomObjectRecord CreateCustomObject create a custom object record
+func (z *Client) CreateCustomObjectRecord(
+	ctx context.Context, record CustomObjectRecord, customObjectKey string,
+) (CustomObjectRecord, error) {
+
+	var data, result struct {
+		CustomObjectRecord CustomObjectRecord `json:"custom_object_record"`
+	}
+	data.CustomObjectRecord = record
+
+	body, err := z.post(ctx, fmt.Sprintf("/custom_objects/%s/records.json", customObjectKey), data)
+	if err != nil {
+		return CustomObjectRecord{}, err
+	}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return CustomObjectRecord{}, err
+	}
+	return result.CustomObjectRecord, nil
+}
+
+// SearchCustomObjectRecords search for a custom object record by the name field
+// https://developer.zendesk.com/api-reference/custom-objects/custom_object_records/#search-custom-object-records
+func (z *Client) SearchCustomObjectRecords(
+	ctx context.Context, customObjectKey string, opts *CustomObjectListOptions) ([]CustomObjectRecord, Page, error) {
+	var result struct {
+		CustomObjectRecords []CustomObjectRecord `json:"custom_object_records"`
+		Page
+	}
+	tmp := opts
+	if tmp == nil {
+		tmp = &CustomObjectListOptions{}
+	}
+	url := fmt.Sprintf("/custom_objects/%s/records/autocomplete", customObjectKey)
+	urlWithOptions, err := addOptions(url, tmp)
+	body, err := z.get(ctx, urlWithOptions)
+
+	if err != nil {
+		return nil, Page{}, err
+	}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, Page{}, err
+	}
+	return result.CustomObjectRecords, result.Page, nil
+}

--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -110,6 +110,21 @@ func (mr *ClientMockRecorder) CreateBrand(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBrand", reflect.TypeOf((*Client)(nil).CreateBrand), arg0, arg1)
 }
 
+// CreateCustomObjectRecord mocks base method.
+func (m *Client) CreateCustomObjectRecord(arg0 context.Context, arg1 zendesk.CustomObjectRecord, arg2 string) (zendesk.CustomObjectRecord, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateCustomObjectRecord", arg0, arg1, arg2)
+	ret0, _ := ret[0].(zendesk.CustomObjectRecord)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateCustomObjectRecord indicates an expected call of CreateCustomObjectRecord.
+func (mr *ClientMockRecorder) CreateCustomObjectRecord(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomObjectRecord", reflect.TypeOf((*Client)(nil).CreateCustomObjectRecord), arg0, arg1, arg2)
+}
+
 // CreateDynamicContentItem mocks base method.
 func (m *Client) CreateDynamicContentItem(arg0 context.Context, arg1 zendesk.DynamicContentItem) (zendesk.DynamicContentItem, error) {
 	m.ctrl.T.Helper()
@@ -1451,6 +1466,22 @@ func (m *Client) SearchCount(arg0 context.Context, arg1 *zendesk.CountOptions) (
 func (mr *ClientMockRecorder) SearchCount(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCount", reflect.TypeOf((*Client)(nil).SearchCount), arg0, arg1)
+}
+
+// SearchCustomObjectRecords mocks base method.
+func (m *Client) SearchCustomObjectRecords(arg0 context.Context, arg1 string, arg2 *zendesk.CustomObjectListOptions) ([]zendesk.CustomObjectRecord, zendesk.Page, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchCustomObjectRecords", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]zendesk.CustomObjectRecord)
+	ret1, _ := ret[1].(zendesk.Page)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// SearchCustomObjectRecords indicates an expected call of SearchCustomObjectRecords.
+func (mr *ClientMockRecorder) SearchCustomObjectRecords(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCustomObjectRecords", reflect.TypeOf((*Client)(nil).SearchCustomObjectRecords), arg0, arg1, arg2)
 }
 
 // SearchUsers mocks base method.

--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -1363,6 +1363,22 @@ func (mr *ClientMockRecorder) GetWebhookSigningSecret(arg0, arg1 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWebhookSigningSecret", reflect.TypeOf((*Client)(nil).GetWebhookSigningSecret), arg0, arg1)
 }
 
+// ListCustomObjectRecords mocks base method.
+func (m *Client) ListCustomObjectRecords(arg0 context.Context, arg1 string, arg2 *zendesk.CustomObjectListOptions) ([]zendesk.CustomObjectRecord, zendesk.Page, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCustomObjectRecords", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]zendesk.CustomObjectRecord)
+	ret1, _ := ret[1].(zendesk.Page)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListCustomObjectRecords indicates an expected call of ListCustomObjectRecords.
+func (mr *ClientMockRecorder) ListCustomObjectRecords(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCustomObjectRecords", reflect.TypeOf((*Client)(nil).ListCustomObjectRecords), arg0, arg1, arg2)
+}
+
 // ListInstallations mocks base method.
 func (m *Client) ListInstallations(arg0 context.Context) ([]zendesk.AppInstallation, error) {
 	m.ctrl.T.Helper()
@@ -1469,7 +1485,7 @@ func (mr *ClientMockRecorder) SearchCount(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // SearchCustomObjectRecords mocks base method.
-func (m *Client) SearchCustomObjectRecords(arg0 context.Context, arg1 string, arg2 *zendesk.CustomObjectListOptions) ([]zendesk.CustomObjectRecord, zendesk.Page, error) {
+func (m *Client) SearchCustomObjectRecords(arg0 context.Context, arg1 string, arg2 *zendesk.CustomObjectAutocompleteOptions) ([]zendesk.CustomObjectRecord, zendesk.Page, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SearchCustomObjectRecords", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]zendesk.CustomObjectRecord)

--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -1531,6 +1531,21 @@ func (mr *ClientMockRecorder) SetDefaultOrganization(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaultOrganization", reflect.TypeOf((*Client)(nil).SetDefaultOrganization), arg0, arg1)
 }
 
+// ShowCustomObjectRecord mocks base method.
+func (m *Client) ShowCustomObjectRecord(arg0 context.Context, arg1, arg2 string) (*zendesk.CustomObjectRecord, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShowCustomObjectRecord", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*zendesk.CustomObjectRecord)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShowCustomObjectRecord indicates an expected call of ShowCustomObjectRecord.
+func (mr *ClientMockRecorder) ShowCustomObjectRecord(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShowCustomObjectRecord", reflect.TypeOf((*Client)(nil).ShowCustomObjectRecord), arg0, arg1, arg2)
+}
+
 // UpdateAutomation mocks base method.
 func (m *Client) UpdateAutomation(arg0 context.Context, arg1 int64, arg2 zendesk.Automation) (zendesk.Automation, error) {
 	m.ctrl.T.Helper()
@@ -1559,6 +1574,21 @@ func (m *Client) UpdateBrand(arg0 context.Context, arg1 int64, arg2 zendesk.Bran
 func (mr *ClientMockRecorder) UpdateBrand(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBrand", reflect.TypeOf((*Client)(nil).UpdateBrand), arg0, arg1, arg2)
+}
+
+// UpdateCustomObjectRecord mocks base method.
+func (m *Client) UpdateCustomObjectRecord(arg0 context.Context, arg1, arg2 string, arg3 zendesk.CustomObjectRecord) (*zendesk.CustomObjectRecord, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCustomObjectRecord", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*zendesk.CustomObjectRecord)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCustomObjectRecord indicates an expected call of UpdateCustomObjectRecord.
+func (mr *ClientMockRecorder) UpdateCustomObjectRecord(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCustomObjectRecord", reflect.TypeOf((*Client)(nil).UpdateCustomObjectRecord), arg0, arg1, arg2, arg3)
 }
 
 // UpdateDynamicContentItem mocks base method.


### PR DESCRIPTION
Introduce the new [custom_objects_v2](https://developer.zendesk.com/api-reference/custom-objects/introduction/).
The code allows the usage of the following APIs:

- CreateCustomObjectRecord
- SearchCustomObjectRecords
- ListCustomObjectRecords
- ShowCustomObjectRecord
- UpdateCustomObjectRecord