### PR TITLE
add pagination and sorting options to tickets from view API

### DIFF
--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -1165,18 +1165,19 @@ func (mr *ClientMockRecorder) GetTickets(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // GetTicketsFromView mocks base method.
-func (m *Client) GetTicketsFromView(arg0 context.Context, arg1 int64) ([]zendesk.Ticket, error) {
+func (m *Client) GetTicketsFromView(arg0 context.Context, arg1 int64, arg2 *zendesk.TicketListOptions) ([]zendesk.Ticket, zendesk.Page, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTicketsFromView", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetTicketsFromView", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]zendesk.Ticket)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(zendesk.Page)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetTicketsFromView indicates an expected call of GetTicketsFromView.
-func (mr *ClientMockRecorder) GetTicketsFromView(arg0, arg1 interface{}) *gomock.Call {
+func (mr *ClientMockRecorder) GetTicketsFromView(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTicketsFromView", reflect.TypeOf((*Client)(nil).GetTicketsFromView), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTicketsFromView", reflect.TypeOf((*Client)(nil).GetTicketsFromView), arg0, arg1, arg2)
 }
 
 // GetTrigger mocks base method.


### PR DESCRIPTION
Adding pagination and sorting that was missing from the tickets from view function.
The new parameters will break code that used the previous version of the function.