### PR TITLE
feat: add SearchCustomObjectRecords function

### DIFF
--- a/zendesk/custom_object.go
+++ b/zendesk/custom_object.go
@@ -24,10 +24,13 @@ type CustomObjectRecord struct {
 type CustomObjectAPI interface {
 	CreateCustomObjectRecord(
 		ctx context.Context, record CustomObjectRecord, customObjectKey string) (CustomObjectRecord, error)
-	SearchCustomObjectRecords(
+	AutocompleteSearchCustomObjectRecords(
 		ctx context.Context,
 		customObjectKey string,
 		opts *CustomObjectAutocompleteOptions,
+	) ([]CustomObjectRecord, Page, error)
+	SearchCustomObjectRecords(
+		ctx context.Context, customObjectKey string, opts *SearchCustomObjectRecordsOptions,
 	) ([]CustomObjectRecord, Page, error)
 	ListCustomObjectRecords(
 		ctx context.Context, customObjectKey string, opts *CustomObjectListOptions) ([]CustomObjectRecord, Page, error)
@@ -98,10 +101,11 @@ func (z *Client) ListCustomObjectRecords(
 	return result.CustomObjectRecords, result.Page, nil
 }
 
-// SearchCustomObjectRecords search for a custom object record by the name field
-// https://developer.zendesk.com/api-reference/custom-objects/custom_object_records/#search-custom-object-records
-func (z *Client) SearchCustomObjectRecords(
-	ctx context.Context, customObjectKey string, opts *CustomObjectAutocompleteOptions) ([]CustomObjectRecord, Page, error) {
+// AutocompleteSearchCustomObjectRecords search for a custom object record by the name field
+// https://developer.zendesk.com/api-reference/custom-objects/custom_object_records/#autocomplete-custom-object-record-search
+func (z *Client) AutocompleteSearchCustomObjectRecords(
+	ctx context.Context, customObjectKey string, opts *CustomObjectAutocompleteOptions,
+) ([]CustomObjectRecord, Page, error) {
 	var result struct {
 		CustomObjectRecords []CustomObjectRecord `json:"custom_object_records"`
 		Page
@@ -111,6 +115,44 @@ func (z *Client) SearchCustomObjectRecords(
 		tmp = &CustomObjectAutocompleteOptions{}
 	}
 	url := fmt.Sprintf("/custom_objects/%s/records/autocomplete", customObjectKey)
+	urlWithOptions, err := addOptions(url, tmp)
+	body, err := z.get(ctx, urlWithOptions)
+
+	if err != nil {
+		return nil, Page{}, err
+	}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, Page{}, err
+	}
+	return result.CustomObjectRecords, result.Page, nil
+}
+
+type SearchCustomObjectRecordsOptions struct {
+	PageOptions
+
+	// One of name, created_at, updated_at, -name, -created_at, or -updated_at.
+	// The - denotes the sort will be descending. Defaults to sorting by relevance.
+	Sort string `url:"sort,omitempty"`
+
+	// Query string
+	Query string `url:"query,omitempty"`
+}
+
+// SearchCustomObjectRecords search for a custom object record by the name field
+// https://developer.zendesk.com/api-reference/custom-objects/custom_object_records/#search-custom-object-records
+func (z *Client) SearchCustomObjectRecords(
+	ctx context.Context, customObjectKey string, opts *SearchCustomObjectRecordsOptions,
+) ([]CustomObjectRecord, Page, error) {
+	var result struct {
+		CustomObjectRecords []CustomObjectRecord `json:"custom_object_records"`
+		Page
+	}
+	tmp := opts
+	if tmp == nil {
+		tmp = &SearchCustomObjectRecordsOptions{}
+	}
+	url := fmt.Sprintf("/custom_objects/%s/records/search", customObjectKey)
 	urlWithOptions, err := addOptions(url, tmp)
 	body, err := z.get(ctx, urlWithOptions)
 

--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -80,6 +80,22 @@ func (mr *ClientMockRecorder) AddUserTags(arg0, arg1, arg2 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserTags", reflect.TypeOf((*Client)(nil).AddUserTags), arg0, arg1, arg2)
 }
 
+// AutocompleteSearchCustomObjectRecords mocks base method.
+func (m *Client) AutocompleteSearchCustomObjectRecords(arg0 context.Context, arg1 string, arg2 *zendesk.CustomObjectAutocompleteOptions) ([]zendesk.CustomObjectRecord, zendesk.Page, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AutocompleteSearchCustomObjectRecords", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]zendesk.CustomObjectRecord)
+	ret1, _ := ret[1].(zendesk.Page)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// AutocompleteSearchCustomObjectRecords indicates an expected call of AutocompleteSearchCustomObjectRecords.
+func (mr *ClientMockRecorder) AutocompleteSearchCustomObjectRecords(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AutocompleteSearchCustomObjectRecords", reflect.TypeOf((*Client)(nil).AutocompleteSearchCustomObjectRecords), arg0, arg1, arg2)
+}
+
 // CreateAutomation mocks base method.
 func (m *Client) CreateAutomation(arg0 context.Context, arg1 zendesk.Automation) (zendesk.Automation, error) {
 	m.ctrl.T.Helper()
@@ -1486,7 +1502,7 @@ func (mr *ClientMockRecorder) SearchCount(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // SearchCustomObjectRecords mocks base method.
-func (m *Client) SearchCustomObjectRecords(arg0 context.Context, arg1 string, arg2 *zendesk.CustomObjectAutocompleteOptions) ([]zendesk.CustomObjectRecord, zendesk.Page, error) {
+func (m *Client) SearchCustomObjectRecords(arg0 context.Context, arg1 string, arg2 *zendesk.SearchCustomObjectRecordsOptions) ([]zendesk.CustomObjectRecord, zendesk.Page, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SearchCustomObjectRecords", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]zendesk.CustomObjectRecord)


### PR DESCRIPTION
Adds a function to the custom object v2 to use:
https://developer.zendesk.com/api-reference/custom-objects/custom_object_records/#search-custom-object-records