### PR TITLE
Unmarshal support for Ticket GroupID

### DIFF
--- a/zendesk/ticket.go
+++ b/zendesk/ticket.go
@@ -63,7 +63,7 @@ type Ticket struct {
 	SubmitterID     int64         `json:"submitter_id,omitempty"`
 	AssigneeID      int64         `json:"assignee_id,omitempty"`
 	OrganizationID  int64         `json:"organization_id,omitempty"`
-	GroupID         int64         `json:"group_id,omitempty"`
+	GroupID         json.Number   `json:"group_id,omitempty"`
 	CollaboratorIDs []int64       `json:"collaborator_ids,omitempty"`
 	FollowerIDs     []int64       `json:"follower_ids,omitempty"`
 	EmailCCIDs      []int64       `json:"email_cc_ids,omitempty"`


### PR DESCRIPTION
There are times that `group_id` is being returned as string instead of number when using  [Show Changes to Ticket](https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/#show-changes-to-ticket) endpoint and causes json unmarshal to fail
```
json: cannot unmarshal string into Go struct field Ticket.result.ticket.group_id of type int64
```

Changing the type of Ticket.GroupID with `json.Number` seems to solve the issue.