### PR TITLE
feat: add export search api support

### DIFF
--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -2548,6 +2548,22 @@ func (mr *ClientMockRecorder) SearchCustomObjectRecords(ctx, customObjectKey, op
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchCustomObjectRecords", reflect.TypeOf((*Client)(nil).SearchCustomObjectRecords), ctx, customObjectKey, opts)
 }
 
+// SearchExport mocks base method.
+func (m *Client) SearchExport(ctx context.Context, opts *zendesk.SearchExportOptions) (zendesk.SearchResults, zendesk.CursorPaginationMeta, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchExport", ctx, opts)
+	ret0, _ := ret[0].(zendesk.SearchResults)
+	ret1, _ := ret[1].(zendesk.CursorPaginationMeta)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// SearchExport indicates an expected call of SearchExport.
+func (mr *ClientMockRecorder) SearchExport(ctx, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchExport", reflect.TypeOf((*Client)(nil).SearchExport), ctx, opts)
+}
+
 // SearchUsers mocks base method.
 func (m *Client) SearchUsers(ctx context.Context, opts *zendesk.SearchUsersOptions) ([]zendesk.User, zendesk.Page, error) {
 	m.ctrl.T.Helper()

--- a/zendesk/search_test.go
+++ b/zendesk/search_test.go
@@ -49,6 +49,31 @@ func TestCountTickets(t *testing.T) {
 	}
 }
 
+func TestSearchExportTickets(t *testing.T) {
+	mockAPI := newMockAPI(http.MethodGet, "search_ticket.json")
+	client := newTestClient(mockAPI)
+	defer mockAPI.Close()
+
+	results, _, err := client.SearchExport(ctx, &SearchExportOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get export search results: %s", err)
+	}
+
+	list := results.List()
+	if len(list) != 1 {
+		t.Fatalf("expected length of sla policies is , but got %d", len(list))
+	}
+
+	ticket, ok := list[0].(Ticket)
+	if !ok {
+		t.Fatalf("Cannot assert %v as a ticket", list[0])
+	}
+
+	if ticket.ID != 4 {
+		t.Fatalf("Ticket did not have the expected id %v", ticket)
+	}
+}
+
 func BenchmarkUnmarshalSearchResults(b *testing.B) {
 	file := readFixture("ticket_result.json")
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This pull request adds an export search API, which is implemented as described in the following documentation:

https://developer.zendesk.com/api-reference/ticketing/ticket-management/search/#export-search-results

I did not use code generation feature because the export search API does not support OBP (Offset-based pagenation).