### PR TITLE
Add Remove Ticket Tags and delete calls with data body

### DIFF
--- a/zendesk/attachment.go
+++ b/zendesk/attachment.go
@@ -174,7 +174,7 @@ func (z *Client) UploadAttachment(ctx context.Context, filename string, token st
 // DeleteUpload deletes a previously uploaded file
 // ref: https://developer.zendesk.com/rest_api/docs/support/attachments#delete-upload
 func (z *Client) DeleteUpload(ctx context.Context, token string) error {
-	return z.delete(ctx, fmt.Sprintf("/uploads/%s.json", token))
+	return z.delete(ctx, fmt.Sprintf("/uploads/%s.json", token), nil)
 }
 
 // GetAttachment returns the current state of an uploaded attachment

--- a/zendesk/automation.go
+++ b/zendesk/automation.go
@@ -166,7 +166,7 @@ func (z *Client) UpdateAutomation(ctx context.Context, id int64, automation Auto
 //
 // ref: https://developer.zendesk.com/rest_api/docs/support/automations#delete-automation
 func (z *Client) DeleteAutomation(ctx context.Context, id int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/automations/%d.json", id))
+	err := z.delete(ctx, fmt.Sprintf("/automations/%d.json", id), nil)
 	if err != nil {
 		return err
 	}

--- a/zendesk/brand.go
+++ b/zendesk/brand.go
@@ -102,7 +102,7 @@ func (z *Client) UpdateBrand(ctx context.Context, brandID int64, brand Brand) (B
 // DeleteBrand deletes the specified brand
 // ref: https://developer.zendesk.com/rest_api/docs/support/brands#delete-brand
 func (z *Client) DeleteBrand(ctx context.Context, brandID int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/brands/%d.json", brandID))
+	err := z.delete(ctx, fmt.Sprintf("/brands/%d.json", brandID), nil)
 
 	if err != nil {
 		return err

--- a/zendesk/dynamic_content.go
+++ b/zendesk/dynamic_content.go
@@ -136,7 +136,7 @@ func (z *Client) UpdateDynamicContentItem(ctx context.Context, id int64, item Dy
 //
 // ref: https://developer.zendesk.com/api-reference/ticketing/ticket-management/dynamic_content/#delete-item
 func (z *Client) DeleteDynamicContentItem(ctx context.Context, id int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/dynamic_content/items/%d.json", id))
+	err := z.delete(ctx, fmt.Sprintf("/dynamic_content/items/%d.json", id), nil)
 	if err != nil {
 		return err
 	}

--- a/zendesk/group.go
+++ b/zendesk/group.go
@@ -135,7 +135,7 @@ func (z *Client) UpdateGroup(ctx context.Context, groupID int64, group Group) (G
 // DeleteGroup deletes the specified group
 // ref: https://developer.zendesk.com/rest_api/docs/support/groups#delete-group
 func (z *Client) DeleteGroup(ctx context.Context, groupID int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/groups/%d.json", groupID))
+	err := z.delete(ctx, fmt.Sprintf("/groups/%d.json", groupID), nil)
 
 	if err != nil {
 		return err

--- a/zendesk/macro.go
+++ b/zendesk/macro.go
@@ -158,7 +158,7 @@ func (z *Client) UpdateMacro(ctx context.Context, macroID int64, macro Macro) (M
 // DeleteMacro deletes the specified macro
 // ref: https://developer.zendesk.com/rest_api/docs/support/macros#delete-macro
 func (z *Client) DeleteMacro(ctx context.Context, macroID int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/macros/%d.json", macroID))
+	err := z.delete(ctx, fmt.Sprintf("/macros/%d.json", macroID), nil)
 
 	if err != nil {
 		return err

--- a/zendesk/mock/client.go
+++ b/zendesk/mock/client.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=api.go -destination=mock/client.go -package=mock -mock_names=API=Client github.com/nukosuke/go-zendesk/zendesk API
 //
+
 // Package mock is a generated GoMock package.
 package mock
 
@@ -20,6 +21,7 @@ import (
 type Client struct {
 	ctrl     *gomock.Controller
 	recorder *ClientMockRecorder
+	isgomock struct{}
 }
 
 // ClientMockRecorder is the mock recorder for Client.
@@ -401,17 +403,17 @@ func (mr *ClientMockRecorder) CreateWebhook(ctx, hook any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *Client) Delete(ctx context.Context, path string) error {
+func (m *Client) Delete(ctx context.Context, path string, data any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, path)
+	ret := m.ctrl.Call(m, "Delete", ctx, path, data)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *ClientMockRecorder) Delete(ctx, path any) *gomock.Call {
+func (mr *ClientMockRecorder) Delete(ctx, path, data any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*Client)(nil).Delete), ctx, path)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*Client)(nil).Delete), ctx, path, data)
 }
 
 // DeleteAutomation mocks base method.
@@ -749,18 +751,18 @@ func (mr *ClientMockRecorder) GetBrand(ctx, brandID any) *gomock.Call {
 }
 
 // GetCountTicketsInViews mocks base method.
-func (m *Client) GetCountTicketsInViews(arg0 context.Context, arg1 []string) ([]zendesk.ViewCount, error) {
+func (m *Client) GetCountTicketsInViews(ctx context.Context, ids []string) ([]zendesk.ViewCount, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCountTicketsInViews", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetCountTicketsInViews", ctx, ids)
 	ret0, _ := ret[0].([]zendesk.ViewCount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCountTicketsInViews indicates an expected call of GetCountTicketsInViews.
-func (mr *ClientMockRecorder) GetCountTicketsInViews(arg0, arg1 interface{}) *gomock.Call {
+func (mr *ClientMockRecorder) GetCountTicketsInViews(ctx, ids any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCountTicketsInViews", reflect.TypeOf((*Client)(nil).GetCountTicketsInViews), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCountTicketsInViews", reflect.TypeOf((*Client)(nil).GetCountTicketsInViews), ctx, ids)
 }
 
 // GetCustomRoles mocks base method.
@@ -2499,6 +2501,20 @@ func (m *Client) Put(ctx context.Context, path string, data any) ([]byte, error)
 func (mr *ClientMockRecorder) Put(ctx, path, data any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*Client)(nil).Put), ctx, path, data)
+}
+
+// RemoveTicketTags mocks base method.
+func (m *Client) RemoveTicketTags(ctx context.Context, ticketID int64, tags []zendesk.Tag) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveTicketTags", ctx, ticketID, tags)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveTicketTags indicates an expected call of RemoveTicketTags.
+func (mr *ClientMockRecorder) RemoveTicketTags(ctx, ticketID, tags any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTicketTags", reflect.TypeOf((*Client)(nil).RemoveTicketTags), ctx, ticketID, tags)
 }
 
 // Search mocks base method.

--- a/zendesk/organization.go
+++ b/zendesk/organization.go
@@ -165,7 +165,7 @@ func (z *Client) UpdateOrganization(ctx context.Context, orgID int64, org Organi
 // DeleteOrganization deletes the specified organization
 // ref: https://developer.zendesk.com/rest_api/docs/support/organizations#delete-organization
 func (z *Client) DeleteOrganization(ctx context.Context, orgID int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/organizations/%d.json", orgID))
+	err := z.delete(ctx, fmt.Sprintf("/organizations/%d.json", orgID), nil)
 	if err != nil {
 		return err
 	}

--- a/zendesk/sla_policy.go
+++ b/zendesk/sla_policy.go
@@ -177,7 +177,7 @@ func (z *Client) UpdateSLAPolicy(ctx context.Context, id int64, slaPolicy SLAPol
 //
 // ref: https://developer.zendesk.com/rest_api/docs/support/slas/policies#delete-slaPolicy
 func (z *Client) DeleteSLAPolicy(ctx context.Context, id int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/slas/policies/%d.json", id))
+	err := z.delete(ctx, fmt.Sprintf("/slas/policies/%d.json", id), nil)
 	if err != nil {
 		return err
 	}

--- a/zendesk/tag.go
+++ b/zendesk/tag.go
@@ -17,6 +17,7 @@ type TagAPI interface {
 	AddTicketTags(ctx context.Context, ticketID int64, tags []Tag) ([]Tag, error)
 	AddOrganizationTags(ctx context.Context, organizationID int64, tags []Tag) ([]Tag, error)
 	AddUserTags(ctx context.Context, userID int64, tags []Tag) ([]Tag, error)
+	RemoveTicketTags(ctx context.Context, ticketID int64, tags []Tag) error
 }
 
 // GetTicketTags get ticket tag list
@@ -143,4 +144,16 @@ func (z *Client) AddUserTags(ctx context.Context, userID int64, tags []Tag) ([]T
 		return nil, err
 	}
 	return result.Tags, nil
+}
+
+// RemoveTicketTags remove tags from ticket
+//
+// ref: https://developer.zendesk.com/rest_api/docs/support/tags#remove-tags
+func (z *Client) RemoveTicketTags(ctx context.Context, ticketID int64, tags []Tag) error {
+	var data struct {
+		Tags []Tag `json:"tags"`
+	}
+	data.Tags = tags
+	err := z.delete(ctx, fmt.Sprintf("/tickets/%d/tags", ticketID), data)
+	return err
 }

--- a/zendesk/target.go
+++ b/zendesk/target.go
@@ -125,7 +125,7 @@ func (z *Client) UpdateTarget(ctx context.Context, targetID int64, field Target)
 // DeleteTarget deletes the specified target
 // ref: https://developer.zendesk.com/rest_api/docs/support/targets#delete-target
 func (z *Client) DeleteTarget(ctx context.Context, targetID int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/targets/%d.json", targetID))
+	err := z.delete(ctx, fmt.Sprintf("/targets/%d.json", targetID), nil)
 
 	if err != nil {
 		return err

--- a/zendesk/ticket.go
+++ b/zendesk/ticket.go
@@ -328,7 +328,7 @@ func (z *Client) UpdateTicket(ctx context.Context, ticketID int64, ticket Ticket
 // DeleteTicket deletes the specified ticket
 // ref: https://developer.zendesk.com/rest_api/docs/support/tickets#delete-ticket
 func (z *Client) DeleteTicket(ctx context.Context, ticketID int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/tickets/%d.json", ticketID))
+	err := z.delete(ctx, fmt.Sprintf("/tickets/%d.json", ticketID), nil)
 
 	if err != nil {
 		return err

--- a/zendesk/ticket_field.go
+++ b/zendesk/ticket_field.go
@@ -145,7 +145,7 @@ func (z *Client) UpdateTicketField(ctx context.Context, ticketID int64, field Ti
 // DeleteTicketField deletes the specified ticket field
 // ref: https://developer.zendesk.com/rest_api/docs/support/ticket_fields#delete-ticket-field
 func (z *Client) DeleteTicketField(ctx context.Context, ticketID int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/ticket_fields/%d.json", ticketID))
+	err := z.delete(ctx, fmt.Sprintf("/ticket_fields/%d.json", ticketID), nil)
 
 	if err != nil {
 		return err

--- a/zendesk/ticket_form.go
+++ b/zendesk/ticket_form.go
@@ -139,7 +139,7 @@ func (z *Client) UpdateTicketForm(ctx context.Context, id int64, form TicketForm
 // DeleteTicketForm deletes the specified ticket form
 // ref: https://developer.zendesk.com/rest_api/docs/support/ticket_forms#delete-ticket-form
 func (z *Client) DeleteTicketForm(ctx context.Context, id int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/ticket_forms/%d.json", id))
+	err := z.delete(ctx, fmt.Sprintf("/ticket_forms/%d.json", id), nil)
 	if err != nil {
 		return err
 	}

--- a/zendesk/trigger.go
+++ b/zendesk/trigger.go
@@ -163,7 +163,7 @@ func (z *Client) UpdateTrigger(ctx context.Context, id int64, trigger Trigger) (
 //
 // ref: https://developer.zendesk.com/rest_api/docs/support/triggers#delete-trigger
 func (z *Client) DeleteTrigger(ctx context.Context, id int64) error {
-	err := z.delete(ctx, fmt.Sprintf("/triggers/%d.json", id))
+	err := z.delete(ctx, fmt.Sprintf("/triggers/%d.json", id), nil)
 	if err != nil {
 		return err
 	}

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -109,7 +109,7 @@ func (z *Client) UpdateWebhook(ctx context.Context, webhookID string, hook *Webh
 //
 // https://developer.zendesk.com/api-reference/event-connectors/webhooks/webhooks/#delete-webhook
 func (z *Client) DeleteWebhook(ctx context.Context, webhookID string) error {
-	err := z.delete(ctx, fmt.Sprintf("/webhooks/%s", webhookID))
+	err := z.delete(ctx, fmt.Sprintf("/webhooks/%s", webhookID), nil)
 	if err != nil {
 		return err
 	}

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -38,7 +39,7 @@ type (
 		Get(ctx context.Context, path string) ([]byte, error)
 		Post(ctx context.Context, path string, data interface{}) ([]byte, error)
 		Put(ctx context.Context, path string, data interface{}) ([]byte, error)
-		Delete(ctx context.Context, path string) error
+		Delete(ctx context.Context, path string, data interface{}) error
 	}
 
 	// CursorPagination contains options for using cursor pagination.
@@ -257,8 +258,17 @@ func (z *Client) patch(ctx context.Context, path string, data interface{}) ([]by
 }
 
 // delete sends data to API and returns an error if unsuccessful
-func (z *Client) delete(ctx context.Context, path string) error {
-	req, err := http.NewRequest(http.MethodDelete, z.baseURL.String()+path, nil)
+func (z *Client) delete(ctx context.Context, path string, data interface{}) error {
+	var b io.Reader
+	if data != nil {
+		bytes, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+		b = strings.NewReader(string(bytes))
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, z.baseURL.String()+path, b)
 	if err != nil {
 		return err
 	}
@@ -362,6 +372,6 @@ func (z *Client) Put(ctx context.Context, path string, data interface{}) ([]byte
 }
 
 // Delete allows users to send requests not yet implemented
-func (z *Client) Delete(ctx context.Context, path string) error {
-	return z.delete(ctx, path)
+func (z *Client) Delete(ctx context.Context, path string, data interface{}) error {
+	return z.delete(ctx, path, data)
 }

--- a/zendesk/zendesk_test.go
+++ b/zendesk/zendesk_test.go
@@ -276,7 +276,7 @@ func TestDelete(t *testing.T) {
 	}))
 
 	c := newTestClient(mockAPI)
-	err := c.delete(ctx, "/foo/id")
+	err := c.delete(ctx, "/foo/id", nil)
 	if err != nil {
 		t.Fatalf("Failed to send request: %s", err)
 	}
@@ -289,7 +289,7 @@ func TestDeleteFailure(t *testing.T) {
 	}))
 
 	c := newTestClient(mockAPI)
-	err := c.delete(ctx, "/foo/id")
+	err := c.delete(ctx, "/foo/id", nil)
 	if err == nil {
 		t.Fatalf("Failed to recieve error from Delete")
 	}


### PR DESCRIPTION
Add support for removing Ticket Tags. This requires changing the Delete function because a data body is required as part of the request.
https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#remove-tags